### PR TITLE
chore(bug): use lazygit tabs

### DIFF
--- a/modules/home-manager/cli/programs/lazygit.nix
+++ b/modules/home-manager/cli/programs/lazygit.nix
@@ -10,12 +10,6 @@
           pager = "${config.programs.git.delta.package}/bin/delta --dark --paging=never";
         };
       };
-      os = {
-        editPreset = "nvim-remote";
-        edit = ''[ -z "$NVIM" ] && (nvim -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote {{filename}})'';
-        editAtLine = ''[ -z "$NVIM" ] && (nvim +{{line}} -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" &&  nvim --server "$NVIM" --remote {{filename}} && nvim --server "$NVIM" --remote-send ":{{line}}<CR>")'';
-        openDirInEditor = ''[ -z "$NVIM" ] && (nvim -- {{dir}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote {{dir}})'';
-      };
     };
   };
 }


### PR DESCRIPTION
There is a bug when having oil as active buffer, lazygit edit file via plugin, will neither focus on the file nor will it open a correct buffer.
The buffer seems to miss line numbers and has not loaded successfully.

Tabs are not ideal IMO, but better than any other try as far :(