### PR TITLE
nixos: bind lib in env module and remove stale nixberry import

### DIFF
--- a/hosts/nixberry/default.nix
+++ b/hosts/nixberry/default.nix
@@ -6,8 +6,6 @@
 {
   imports = [
     inputs.nixos-hardware.nixosModules.raspberry-pi-3
-
-    ../../modules/nixos
   ];
 
   # Host specific configuration

--- a/modules/nixos/system/env.nix
+++ b/modules/nixos/system/env.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   inputs,
+  lib,
   ...
 }:
 {


### PR DESCRIPTION
### Motivation
- Fix Nix evaluation failures caused by `lib.optionals` being invoked in the env module without `lib` bound in the module argument set. 
- Prevent host evaluation errors for `nixberry` by removing a stale `../../modules/nixos` import that no longer exists after the restructure.

### Description
- Add `lib` to the module arguments of `modules/nixos/system/env.nix` so `lib.optionals` is properly available during evaluation. 
- Remove the obsolete `../../modules/nixos` import from `hosts/nixberry/default.nix` so the host relies on the `nixosModules` list provided by `flake.nix` like the other hosts. 
- Changes affect `modules/nixos/system/env.nix` and `hosts/nixberry/default.nix`.

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors. 
- Confirmed the two files were modified via `git status`/`git diff --stat`. 
- Attempted `nix eval .#nixosConfigurations.nixberry.config.system.build.toplevel.drvPath` to validate evaluation but it could not be executed in this environment because `nix` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2560e3a5d8832bb5fa643c9a373544)