### PR TITLE
Refactor env package selection with lib.attrValues and remove redundant nixberry import

### DIFF
--- a/hosts/nixberry/default.nix
+++ b/hosts/nixberry/default.nix
@@ -6,8 +6,6 @@
 {
   imports = [
     inputs.nixos-hardware.nixosModules.raspberry-pi-3
-
-    ../../modules/nixos
   ];
 
   # Host specific configuration

--- a/modules/nixos/system/env.nix
+++ b/modules/nixos/system/env.nix
@@ -2,40 +2,34 @@
   pkgs,
   config,
   inputs,
+  lib,
   ...
 }:
 {
   environment = {
     systemPackages =
-      with pkgs;
-      [
-        dnsutils # dig, nslookup, etc.
-        inetutils # ping, traceroute, etc.
-
-        # Cpu & Networking tools
-        htop
-        curl
-
-        # Tooling
-        git
-        curl
-        fzf
-        file
-
-        jq
-        yq-go
-        gawk
-        gnused
-
-        p7zip
-        gnumake
-      ]
+      lib.attrValues {
+        inherit (pkgs)
+          curl
+          dnsutils
+          file
+          fzf
+          gawk
+          git
+          gnumake
+          gnused
+          htop
+          inetutils
+          jq
+          p7zip
+          yq-go
+          ;
+      }
       # TODO: wtf?
-      ++ lib.optionals (!config.hostConfig.roles.desktop) [
-        inputs.neonix.packages.${pkgs.stdenv.hostPlatform.system}.mini
-        jq
-        tmux
-      ];
+      ++ lib.optionals (!config.hostConfig.roles.desktop) (lib.attrValues {
+        inherit (inputs.neonix.packages.${pkgs.stdenv.hostPlatform.system}) mini;
+        inherit (pkgs) jq tmux;
+      });
     variables = {
       EDITOR = "vim";
       VISUAL = "vim";


### PR DESCRIPTION
### Motivation
- Simplify and DRY up package selection in `modules/nixos/system/env.nix` by using `lib.attrValues` and make `lib` available to the module. 
- Remove a redundant import from `hosts/nixberry/default.nix` to avoid double-loading a common module. 

### Description
- Add `lib` to the argument list of `modules/nixos/system/env.nix` and refactor `environment.systemPackages` to use `lib.attrValues` to collect packages from `pkgs`.
- Replace the previous explicit list and concatenation with `lib.optionals` combined with `lib.attrValues` to conditionally include `inputs.neonix.packages.${pkgs.stdenv.hostPlatform.system}.mini`, `jq`, and `tmux` when not a desktop role.
- Remove the `../../modules/nixos` entry from `hosts/nixberry/default.nix`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2560e3a5d8832bb5fa643c9a373544)