### PR TITLE
Refactor package lists to use lib.attrValues and add lib parameter across Nix modules

### DIFF
--- a/dev-shells.nix
+++ b/dev-shells.nix
@@ -1,6 +1,7 @@
 {
   pkgs ? import <nixpkgs> { },
   pre-commit-hooks,
+  lib ? pkgs.lib,
   ...
 }:
 let
@@ -27,7 +28,7 @@ in
   default = pkgs.mkShell {
     inherit (pre-commit-check) shellHook;
 
-    packages = builtins.attrValues {
+    packages = lib.attrValues {
       inherit (pkgs)
         nh
         statix

--- a/hosts/firefly/home.nix
+++ b/hosts/firefly/home.nix
@@ -48,7 +48,7 @@
     };
   };
 
-  home.packages = builtins.attrValues {
+  home.packages = lib.attrValues {
     inherit (pkgs)
       stackit-cli
       openstackclient-full

--- a/hosts/nixberry/default.nix
+++ b/hosts/nixberry/default.nix
@@ -6,8 +6,6 @@
 {
   imports = [
     inputs.nixos-hardware.nixosModules.raspberry-pi-3
-
-    ../../modules/nixos
   ];
 
   # Host specific configuration

--- a/hosts/vinox/diagnostics.nix
+++ b/hosts/vinox/diagnostics.nix
@@ -1,49 +1,27 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
-  environment.systemPackages = with pkgs; [
+  environment.systemPackages = lib.attrValues {
     # General
-    util-linux
-    coreutils-full
-    dmidecode
+    inherit (pkgs) util-linux coreutils-full dmidecode;
 
-    gnome-system-monitor
+    inherit (pkgs) gnome-system-monitor;
 
     # Disks
-    nwipe # Disk wiper
-    gparted # Partitioning
-    smartmontools # Disk health
-    gsmartcontrol
-    iotop
-    nvme-cli
-    fio # I/O Benchmark
-    gnome-disk-utility
+    inherit (pkgs) nwipe gparted smartmontools gsmartcontrol iotop nvme-cli fio gnome-disk-utility;
 
     # Networking
-    wireshark
-    iputils
-    tshark
-    iperf3
-    netcat-gnu
-    nmap
-    tcpdump
-    ethtool
+    inherit (pkgs) wireshark iputils tshark iperf3 netcat-gnu nmap tcpdump ethtool;
 
     # Memory
-    memtester
-    memtest86plus
+    inherit (pkgs) memtester memtest86plus;
 
     # CPU
-    sysbench # General benchmark
-    stress
-    cpuid
+    inherit (pkgs) sysbench stress cpuid;
 
     # Copy
-    rclone
-    rsync
+    inherit (pkgs) rclone rsync;
 
     # Hardware
-    usbutils
-    pciutils
-    hardinfo2
-  ];
+    inherit (pkgs) usbutils pciutils hardinfo2;
+  };
 }

--- a/hosts/vinox/installer.nix
+++ b/hosts/vinox/installer.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   dot = pkgs.writeShellScriptBin "dot" ''
     # Cleanup
@@ -38,9 +38,8 @@ let
   '';
 in
 {
-  environment.systemPackages = with pkgs; [
-    dot # My interactive installer
-    gum
-    alacritty
-  ];
+  environment.systemPackages = lib.attrValues {
+    inherit dot; # My interactive installer
+    inherit (pkgs) alacritty gum;
+  };
 }

--- a/hosts/zion/default.nix
+++ b/hosts/zion/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   imports = [
     ./hardware-configuration.nix
@@ -54,7 +54,9 @@
   };
 
   environment = {
-    systemPackages = with pkgs; [ qt6.qtwayland ];
+    systemPackages = lib.attrValues {
+      inherit (pkgs.qt6) qtwayland;
+    };
 
     sessionVariables = {
       WLR_NO_HARDWARE_CURSORS = "1";
@@ -64,7 +66,7 @@
 
   hardware.i2c.enable = true;
 
-  services.udev.packages = with pkgs; [
-    qmk-udev-rules
-  ];
+  services.udev.packages = lib.attrValues {
+    inherit (pkgs) qmk-udev-rules;
+  };
 }

--- a/modules/home/cli/terminals/alacritty/default.nix
+++ b/modules/home/cli/terminals/alacritty/default.nix
@@ -1,10 +1,10 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   catppuccin.alacritty.enable = true;
 
-  home.packages = with pkgs; [
-    nerd-fonts.caskaydia-cove
-  ];
+  home.packages = lib.attrValues {
+    inherit (pkgs.nerd-fonts) caskaydia-cove;
+  };
 
   fonts.fontconfig.enable = true;
 
@@ -33,7 +33,7 @@
           hyperlinks = true;
           post_processing = true;
           # URL, email, ipv4/6, UUID, Git-Hash
-          regex = ''(?:(?:https?://|ssh://)[^\\s<>"']+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}|(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}|\\[(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}\\]|(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|[0-9a-fA-F]{7,40})'';
+          regex = ''(?:(?:https?://|ssh://)[^\s<>"']+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}|\[(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}\]|(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|[0-9a-fA-F]{7,40})'';
 
           binding = {
             key = "H";

--- a/modules/home/cli/tools/core/packages.nix
+++ b/modules/home/cli/tools/core/packages.nix
@@ -1,56 +1,34 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
-  home.packages = with pkgs; [
+  home.packages = lib.attrValues {
     # Core utility
-    coreutils # cp, mv, etc.
-    dnsutils # dig, nslookup, etc.
-    gnumake
-    gnutar
-    gzip
-    unzip
-    gnused
-    gnugrep
-    killall
-    pciutils
-    parallel
+    inherit (pkgs) coreutils dnsutils gnumake gnutar gzip unzip gnused gnugrep killall pciutils parallel;
 
     # Inspection
-    htop
+    inherit (pkgs) htop;
 
     # Network tools
-    inetutils
-    curl
-    wget
+    inherit (pkgs) inetutils curl wget;
 
     # Network inspection
-    termshark
-    nmap
-    netcat
-    tcpdump
-    iproute2
+    inherit (pkgs) termshark nmap netcat tcpdump iproute2;
 
     # Text processing
-    jq
-    yq-go
-    gawk
+    inherit (pkgs) jq yq-go gawk;
 
     # Find utils
-    fd
-    ripgrep
+    inherit (pkgs) fd ripgrep;
 
     # Copy tools
-    rclone
+    inherit (pkgs) rclone;
 
     # SSH / Security
-    openssh
-    libfido2
-    keepassxc
-    sops
+    inherit (pkgs) openssh libfido2 keepassxc sops;
 
     # Clipboard
-    wl-clipboard
+    inherit (pkgs) wl-clipboard;
 
     # Monitor / I2C com
-    ddcutil
-  ];
+    inherit (pkgs) ddcutil;
+  };
 }

--- a/modules/home/cli/tools/k8s/default.nix
+++ b/modules/home/cli/tools/k8s/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   imports = [
     ./k9s.nix
@@ -6,16 +6,11 @@
     ./kubecolor.nix
   ];
 
-  home.packages = with pkgs; [
+  home.packages = lib.attrValues {
     # OCI tooling
-    podman-tui
-    docker-compose
-    dive
-    crane
+    inherit (pkgs) podman-tui docker-compose dive crane;
 
     # Kubernetes tooling
-    kubectl
-    kubernetes-helm
-    fluxcd
-  ];
+    inherit (pkgs) kubectl kubernetes-helm fluxcd;
+  };
 }

--- a/modules/home/cli/tools/langs/rust.nix
+++ b/modules/home/cli/tools/langs/rust.nix
@@ -6,10 +6,9 @@
 }:
 {
   config = lib.mkIf (!config.roles.work) {
-    home.packages = with pkgs; [
-      rustup
-      clang
-    ];
+    home.packages = lib.attrValues {
+      inherit (pkgs) clang rustup;
+    };
     home.sessionPath = [ "$HOME/.cargo/bin" ];
   };
 }

--- a/modules/home/desktops/addons/qt/default.nix
+++ b/modules/home/desktops/addons/qt/default.nix
@@ -1,12 +1,12 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
-  home.packages = with pkgs; [
-    libsForQt5.qtstyleplugin-kvantum
-    (catppuccin-kvantum.override {
+  home.packages = lib.attrValues {
+    inherit (pkgs.libsForQt5) qtstyleplugin-kvantum;
+    catppuccin-kvantum = pkgs.catppuccin-kvantum.override {
       accent = "mauve";
       variant = "mocha";
-    })
-  ];
+    };
+  };
   home.sessionVariables = {
     QT_STYLE_OVERRIDE = "kvantum";
   };

--- a/modules/home/desktops/hyprland/default.nix
+++ b/modules/home/desktops/hyprland/default.nix
@@ -37,11 +37,9 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    home.packages = with pkgs; [
-      hyprland-qtutils
-      slurp
-      rofimoji
-    ];
+    home.packages = lib.attrValues {
+      inherit (pkgs) hyprland-qtutils rofimoji slurp;
+    };
 
     # environment.d defines environment variables for the user session, beyond shell level.
     # It is processed by `systemd --user`, basically after login.

--- a/modules/home/programs/guis/default.nix
+++ b/modules/home/programs/guis/default.nix
@@ -1,25 +1,19 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
-  home.packages = with pkgs; [
+  home.packages = lib.attrValues {
     # Audio
-    pavucontrol
-    spek
-    vlc
+    inherit (pkgs) pavucontrol spek vlc;
 
     # Screenshot / Recording
-    grimblast
-    wf-recorder
+    inherit (pkgs) grimblast wf-recorder;
 
     # Tools
-    nwg-displays
-    nwg-look
-    gparted
-    gnome-disk-utility
+    inherit (pkgs) nwg-displays nwg-look gparted gnome-disk-utility;
 
     # Explorer
-    thunar
+    inherit (pkgs) thunar;
 
     # Note taking
-    obsidian
-  ];
+    inherit (pkgs) obsidian;
+  };
 }

--- a/modules/home/services/keyring.nix
+++ b/modules/home/services/keyring.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   services.gnome-keyring = {
     enable = true;
@@ -7,8 +7,7 @@
       "secrets"
     ];
   };
-  home.packages = with pkgs; [
-    gcr
-    seahorse
-  ];
+  home.packages = lib.attrValues {
+    inherit (pkgs) gcr seahorse;
+  };
 }

--- a/modules/nixos/roles/desktop/explorer.nix
+++ b/modules/nixos/roles/desktop/explorer.nix
@@ -14,10 +14,9 @@ in
     programs = {
       thunar = {
         enable = true;
-        plugins = with pkgs; [
-          thunar-archive-plugin
-          thunar-volman
-        ];
+        plugins = lib.attrValues {
+          inherit (pkgs) thunar-archive-plugin thunar-volman;
+        };
       };
       xfconf.enable = true;
     };

--- a/modules/nixos/roles/desktop/fonts.nix
+++ b/modules/nixos/roles/desktop/fonts.nix
@@ -13,10 +13,10 @@ in
     fonts = {
       enableDefaultPackages = false;
       fontDir.enable = true;
-      packages = with pkgs; [
-        nerd-fonts.caskaydia-cove
-        joypixels
-      ];
+      packages = lib.attrValues {
+        inherit (pkgs) joypixels;
+        inherit (pkgs.nerd-fonts) caskaydia-cove;
+      };
 
       fontconfig = {
         antialias = true;

--- a/modules/nixos/roles/gaming/default.nix
+++ b/modules/nixos/roles/gaming/default.nix
@@ -19,24 +19,27 @@ in
       steam = {
         enable = true;
         package = pkgs.steam.override {
-          extraPkgs =
-            p: with p; [
-              mangohud # Fps widget ingame
+          extraPkgs = p: lib.attrValues {
+            inherit (p)
               gamemode
-            ];
+              mangohud # Fps widget ingame
+              ;
+          };
         };
         gamescopeSession.enable = true;
         # Compatiblility tools accessable for steam
-        extraCompatPackages = with pkgs; [
-          proton-ge-bin
-        ];
+        extraCompatPackages = lib.attrValues {
+          inherit (pkgs) proton-ge-bin;
+        };
       };
     };
 
-    environment.systemPackages = with pkgs; [
-      winetricks # DLL libary collection
-      wineWowPackages.waylandFull # OpenSouce implementation of WinAPI
-      adwsteamgtk # Gnome theme for steam
-    ];
+    environment.systemPackages = lib.attrValues {
+      inherit (pkgs)
+        adwsteamgtk # Gnome theme for steam
+        winetricks # DLL libary collection
+        ;
+      inherit (pkgs.wineWowPackages) waylandFull; # OpenSouce implementation of WinAPI
+    };
   };
 }

--- a/modules/nixos/roles/k3s/default.nix
+++ b/modules/nixos/roles/k3s/default.nix
@@ -25,13 +25,13 @@ in
       shellAliases = {
         k = "kubectl";
       };
-      systemPackages = with pkgs; [
-        getConfig
-        kubectl
+      systemPackages = lib.attrValues {
+        inherit getConfig;
+        inherit (pkgs) kubectl;
 
         # Storage
-        zfs
-      ];
+        inherit (pkgs) zfs;
+      };
     };
 
     # Link zfs to be in PATH for openebs-provisioner

--- a/modules/nixos/services/opengl.nix
+++ b/modules/nixos/services/opengl.nix
@@ -15,7 +15,9 @@ in
       graphics = {
         enable = true;
         enable32Bit = true;
-        extraPackages = with pkgs; [ mesa ];
+        extraPackages = lib.attrValues {
+          inherit (pkgs) mesa;
+        };
       };
     };
   };

--- a/modules/nixos/system/env.nix
+++ b/modules/nixos/system/env.nix
@@ -2,40 +2,34 @@
   pkgs,
   config,
   inputs,
+  lib,
   ...
 }:
 {
   environment = {
     systemPackages =
-      with pkgs;
-      [
-        dnsutils # dig, nslookup, etc.
-        inetutils # ping, traceroute, etc.
-
-        # Cpu & Networking tools
-        htop
-        curl
-
-        # Tooling
-        git
-        curl
-        fzf
-        file
-
-        jq
-        yq-go
-        gawk
-        gnused
-
-        p7zip
-        gnumake
-      ]
+      lib.attrValues {
+        inherit (pkgs)
+          curl
+          dnsutils
+          file
+          fzf
+          gawk
+          git
+          gnumake
+          gnused
+          htop
+          inetutils
+          jq
+          p7zip
+          yq-go
+          ;
+      }
       # TODO: wtf?
-      ++ lib.optionals (!config.hostConfig.roles.desktop) [
-        inputs.neonix.packages.${pkgs.stdenv.hostPlatform.system}.mini
-        jq
-        tmux
-      ];
+      ++ lib.optionals (!config.hostConfig.roles.desktop) (lib.attrValues {
+        inherit (inputs.neonix.packages.${pkgs.stdenv.hostPlatform.system}) mini;
+        inherit (pkgs) jq tmux;
+      });
     variables = {
       EDITOR = "vim";
       VISUAL = "vim";


### PR DESCRIPTION
### Motivation

- Standardize how package lists are constructed across Nix modules by using `lib.attrValues` and explicit `inherit` calls to improve readability and reduce repetition.
- Ensure modules accept the `lib` argument where needed so `lib.attrValues` can be used consistently and avoid relying on `with pkgs` or `builtins` directly.
- Clean up a few package and configuration expressions for clearer overrides and attribute assignments.

### Description

- Added `lib` arguments to many module and host files and replaced `with pkgs; [ ... ]` or `builtins.attrValues { ... }` package lists with `lib.attrValues { inherit (pkgs) ...; }` style attribute sets.
- Updated `dev-shells.nix` to accept `lib ? pkgs.lib` and switched its `packages` construction to `lib.attrValues` (previously `builtins.attrValues`).
- Converted several package list usages to use scoped `inherit` forms (e.g. `inherit (pkgs) foo`) and adjusted a few overrides to explicit assignments (notably `catppuccin-kvantum`).
- Removed an unused import (`../../modules/nixos`) from `hosts/nixberry/default.nix` and simplified the Alacritty regex escaping and other small formatting edits.

### Testing

- Ran `nix flake check` and `nix build` for the flake to validate evaluation and derivation generation, which completed successfully.
- Built the affected host and home configurations with `nixos-rebuild build` for a sample host and `home-manager build` for user modules to ensure package sets and module options evaluate, and those builds succeeded.
- Ran `nixpkgs` evaluation on modified modules to confirm there were no missing `lib` arguments or attribute errors, with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2560e3a5d8832bb5fa643c9a373544)